### PR TITLE
Deleted OpenGLMathTex

### DIFF
--- a/chanim/chem_objects.py
+++ b/chanim/chem_objects.py
@@ -19,7 +19,6 @@ from manim.mobject.geometry import DashedLine
 from manim.constants import *
 from manim.mobject.geometry import Dot
 from manim.utils.color import YELLOW
-from manim.opengl import OpenGLMathTex
 from manim._config import logger
 
 
@@ -97,7 +96,7 @@ class ChemObject(MathTex):
         )
 
 
-class OpenGLChemObject(OpenGLMathTex):
+class OpenGLChemObject(MathTex):
     """
     `chanimlib.chem_objects.ChemObject`
 


### PR DESCRIPTION
It no longer exists such import. Therefore, deletion of the import and correction of the OpenGLChemObject definition were necessary.