### PR TITLE
Fix text symbol error and hex error

### DIFF
--- a/chanim/chem_objects.py
+++ b/chanim/chem_objects.py
@@ -544,7 +544,7 @@ class ChemWithName(VMobject):
         self, chem, name, name_direction=DOWN, label_constructor=Tex, buff=1, **kwargs
     ):
 
-        super().__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
         if isinstance(
             chem, (ChemObject, ComplexChemIon, ComplexChemCompound, ChemAbove)
@@ -657,6 +657,12 @@ class ReactionVGroup(VGroup):
             if index != 0:
                 iterableable[index].set_y(iterableable[index - 1].get_y())
 
+#Defines TexSymbol for use in the BondBreak class
+class TexSymbol(VMobject):
+                    """
+                    Purely a renaming of VMobjectFromSVGPathstring
+                    """
+                    pass
 
 class BondBreak(DashedLine):
     """


### PR DESCRIPTION
Defines the TexSymbol class and fixes the error that does not find the hex attribute in the ChemWithName class